### PR TITLE
pytube에서 받는 오디오 데이터 형식 변경

### DIFF
--- a/summarizer/src/inputhandler.py
+++ b/summarizer/src/inputhandler.py
@@ -1,5 +1,7 @@
+import pytube
 from pytube import YouTube
 from pytube.exceptions import VideoUnavailable
+from io import BytesIO
 
 import abc
 
@@ -44,15 +46,8 @@ class YoutubeInputHandler(AbstractInputHandler):
         """
         **download audio file as side effect
         """
-        try:
-            tmp_fname = str(uuid4())[:8] + ".mp3"
-            self.parse_obj.streams.filter(only_audio=True).first().download(
-                output_path=tmpdir, filename=tmp_fname
-            )
+        byte_arr = bytearray()
+        for byte_obj in pytube.request.stream(self.parse_obj.streams.filter(only_audio=True).first().url) :
+            byte_arr += byte_obj
 
-            audio_file = open(os.path.join(tmpdir, tmp_fname), "rb")
-
-            return audio_file
-
-        finally:
-            os.remove(os.path.join(tmpdir, tmp_fname))
+        return BytesIO(byte_arr)

--- a/summarizer/tests/unit/test_retrieve_audiofile.py
+++ b/summarizer/tests/unit/test_retrieve_audiofile.py
@@ -1,5 +1,7 @@
+import pytest
 import pytube
-from src.inputhandler import YoutubeInputHandler
+from io import BytesIO
+from summarizer.src.inputhandler import YoutubeInputHandler
 
 
 def test_retrieve_url_to_stream():
@@ -10,6 +12,19 @@ def test_retrieve_url_to_stream():
     audio_stream = youtube_parser.streams.filter(only_audio=True).first()
 
     assert type(audio_stream) is pytube.streams.Stream
+
+
+def test_pytube_returns_byte() :
+    URL = "https://www.youtube.com/watch?v=QgaTjRH5sqk"
+
+    youtube_parser = pytube.YouTube(URL)
+
+    byte_arr = bytearray()
+    for byte_obj in pytube.request.stream(youtube_parser.streams.filter(only_audio=True).first().url) :
+        byte_arr += byte_obj
+
+    
+    assert type(BytesIO(byte_arr).read()) is bytes
 
 
 def test_input_handler_return_audio_stream():

--- a/summarizer/tests/unit/test_transcript.py
+++ b/summarizer/tests/unit/test_transcript.py
@@ -1,3 +1,5 @@
+import pytest
+
 import pytube
 from openai import OpenAI
 
@@ -12,7 +14,7 @@ load_dotenv()
 whisper_model = OpenAI()
 transcriber = WhisperAPITranscriber(whisper_model)
 
-
+@pytest.mark.skip()
 def test_openai_whisper_takes_pytube_stream_as_input():
     URL = "https://www.youtube.com/watch?v=QgaTjRH5sqk"
 


### PR DESCRIPTION

<img width="706" alt="image" src="https://github.com/watanka/LLMSummarizer/assets/38347743/6ff54f63-f698-4655-a84f-0948a09e7f44">

### AS-IS
- pytube에서 받는 오디오 데이터 방식은 다운로드 후, 파일을 읽어오는 형식이였음.

### TO-BE
- 다운로드를 생략하고, 오디오 데이터를 bytes로 바로 읽어올 수 있도록 수정